### PR TITLE
switch to GetVirtualPixels

### DIFF
--- a/macros.h
+++ b/macros.h
@@ -2,9 +2,9 @@
 #define ACQUIRE_IMAGE_PIXELS(im, x, y, w, h, ex) ({ \
     _Pragma("GCC diagnostic push") \
     _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"") \
-    AcquireImagePixels(im, x, y, w, h, ex); \
+    GetVirtualPixels(im, x, y, w, h, ex); \
     _Pragma("GCC diagnostic pop") \
 })
 #else
-#define ACQUIRE_IMAGE_PIXELS(im, x, y, w, h, ex) AcquireImagePixels(im, x, y, w, h, ex)
+#define ACQUIRE_IMAGE_PIXELS(im, x, y, w, h, ex) GetVirtualPixels(im, x, y, w, h, ex)
 #endif


### PR DESCRIPTION
AcquireImagePixels is deprecaed http://www.imagemagick.org/api/deprecate.php#AcquireImagePixels

This fixes the deprecations warnings.  As discussed in #13, this does not make magick thread-safe.  From what I understand, the Go scheduler only allows one goroutine to call across the cgo bridge.  So refactoring the entire codebase to make it thread-safe is premature right now.

```
./color.c:36:13: warning: 'AcquireImagePixels' is deprecated [-Wdeprecated-declarations]
./macros.h:9:50: note: expanded from macro 'ACQUIRE_IMAGE_PIXELS'
/usr/local/Cellar/imagemagick/6.8.9-5/include/ImageMagick-6/magick/deprecate.h:120:4: note: 'AcquireImagePixels' has been explicitly marked deprecated here
# github.com/drewwells/magick
./compat.c:18:13: warning: 'AcquireImagePixels' is deprecated [-Wdeprecated-declarations]
./macros.h:9:50: note: expanded from macro 'ACQUIRE_IMAGE_PIXELS'
/usr/local/Cellar/imagemagick/6.8.9-5/include/ImageMagick-6/magick/deprecate.h:120:4: note: 'AcquireImagePixels' has been explicitly marked deprecated here
# github.com/drewwells/magick
./gif.c:230:13: warning: 'AcquireImagePixels' is deprecated [-Wdeprecated-declarations]
./macros.h:9:50: note: expanded from macro 'ACQUIRE_IMAGE_PIXELS'
/usr/local/Cellar/imagemagick/6.8.9-5/include/ImageMagick-6/magick/deprecate.h:120:4: note: 'AcquireImagePixels' has been explicitly marked deprecated here
./gif.c:251:37: warning: 'AcquireImagePixels' is deprecated [-Wdeprecated-declarations]
./macros.h:9:50: note: expanded from macro 'ACQUIRE_IMAGE_PIXELS'
/usr/local/Cellar/imagemagick/6.8.9-5/include/ImageMagick-6/magick/deprecate.h:120:4: note: 'AcquireImagePixels' has been explicitly marked deprecated here
# github.com/drewwells/magick
./matrix.c:13:13: warning: 'AcquireImagePixels' is deprecated [-Wdeprecated-declarations]
./macros.h:9:50: note: expanded from macro 'ACQUIRE_IMAGE_PIXELS'
/usr/local/Cellar/imagemagick/6.8.9-5/include/ImageMagick-6/magick/deprecate.h:120:4: note: 'AcquireImagePixels' has been explicitly marked deprecated here
```
