### PR TITLE
Add CompositeAlpha mode to GM backend

### DIFF
--- a/composite_gm.go
+++ b/composite_gm.go
@@ -74,6 +74,8 @@ func (im *Image) compositeOperator(c Composite) (int, error) {
 		cc = C.UndefinedCompositeOp
 	case CompositeXor:
 		cc = C.XorCompositeOp
+	case CompositeAlpha:
+		cc = C.CopyOpacityCompositeOp
 	default:
 		return 0, notImplementedError(fmt.Sprintf("composite %s", c))
 	}


### PR DESCRIPTION
CompositeAlpha is missing in the GM backend, it's equivalent should be "CopyOpacityCompositeOp"
