### PR TITLE
Add DecodeDataWithInfo, and info.SetDensity

### DIFF
--- a/gif.go
+++ b/gif.go
@@ -45,7 +45,7 @@ func fixAndDecodeGif(data []byte, try int) (*Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	return decodeData(data, try+1)
+	return decodeData(data, try+1, nil)
 }
 
 // GifEncode encodes the Image as GIF using giflib

--- a/image.go
+++ b/image.go
@@ -177,7 +177,13 @@ func Decode(r io.Reader) (*Image, error) {
 // DecodeData works like Decode, but accepts a
 // []byte rather than an io.Reader.
 func DecodeData(data []byte) (*Image, error) {
-	return decodeData(data, 0)
+	return decodeData(data, 0, nil)
+}
+
+// DecodeDataWithInfo works like DecodeData, but accepts an
+// info argument as well (like Encode)
+func DecodeDataWithInfo(data []byte, info *Info) (*Image, error) {
+	return decodeData(data, 0, info.info)
 }
 
 // DecodeFile works like Decode, but accepts a
@@ -191,11 +197,13 @@ func DecodeFile(filename string) (*Image, error) {
 	return Decode(f)
 }
 
-func decodeData(data []byte, try int) (*Image, error) {
+func decodeData(data []byte, try int, info *C.ImageInfo) (*Image, error) {
 	if len(data) == 0 {
 		return nil, ErrNoData
 	}
-	info := C.CloneImageInfo(nil)
+	if info == nil {
+		info = C.CloneImageInfo(nil)
+	}
 	defer C.DestroyImageInfo(info)
 	var ex C.ExceptionInfo
 	C.GetExceptionInfo(&ex)

--- a/info.go
+++ b/info.go
@@ -62,13 +62,18 @@ func (in *Info) SetColorspace(cs Colorspace) {
 	in.info.colorspace = C.ColorspaceType(cs)
 }
 
+func NewBaseInfo() *Info {
+	cinfo := C.CloneImageInfo(nil)
+	info := new(Info)
+	info.info = cinfo
+	return info
+}
+
 // NewInfo returns a newly allocated *Info structure. Do not
 // create Info objects directly, since they need to allocate
 // some internal structures while being created.
 func NewInfo() *Info {
-	cinfo := C.CloneImageInfo(nil)
-	info := new(Info)
-	info.info = cinfo
+	info := NewBaseInfo()
 	runtime.SetFinalizer(info, func(i *Info) {
 		if i.info != nil {
 			C.DestroyImageInfo(i.info)

--- a/info.go
+++ b/info.go
@@ -5,6 +5,7 @@ package magick
 import "C"
 
 import (
+	"fmt"
 	"runtime"
 	"unsafe"
 )
@@ -43,6 +44,10 @@ func (in *Info) Quality() uint {
 // This parameter does not affect all formats.
 func (in *Info) SetQuality(q uint) {
 	in.info.quality = magickSize(q)
+}
+
+func (in *Info) SetDensity(x_density uint, y_density uint) {
+	in.info.density = C.CString(fmt.Sprintf("%dx%d", x_density, y_density))
 }
 
 // Colorspace returns the colorspace used when encoding the image.


### PR DESCRIPTION
For loading PDF files, we need to specify the density.
Since Encode also takes info argument, it makes sense to be able to Decode with info argument.